### PR TITLE
Use StreamedAsyncHandler for Nakadi event streaming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
             <version>1.2.1</version>
         </dependency>
         <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava-string</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex</groupId>
+            <artifactId>rxjava-reactive-streams</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-core</artifactId>
             <version>1.4.26</version>

--- a/src/main/java/org/zalando/rxnakadi/CursorCommitter.java
+++ b/src/main/java/org/zalando/rxnakadi/CursorCommitter.java
@@ -146,11 +146,11 @@ final class CursorCommitter {
                     Collections.emptySet()));
 
         return
-            httpClient.preparePost(commitUrl)                                                   //
-                      .setHeader(EventStreamHandler.NAKADI_CLIENT_IDENTIFIER_HEADER, sessionId) //
-                      .setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token.getValue())       //
-                      .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")                  //
-                      .setHeader(HttpHeaders.ACCEPT, "application/json")                        //
+            httpClient.preparePost(commitUrl)                                                                    //
+                      .setHeader(SubscriptionAwareEventStreamHandler.NAKADI_CLIENT_IDENTIFIER_HEADER, sessionId) //
+                      .setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token.getValue())                        //
+                      .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")                                   //
+                      .setHeader(HttpHeaders.ACCEPT, "application/json")                                         //
                       .setBody(gson.toJson(payload));
     }
 

--- a/src/main/java/org/zalando/rxnakadi/EventStreamHandler.java
+++ b/src/main/java/org/zalando/rxnakadi/EventStreamHandler.java
@@ -6,19 +6,19 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.HttpResponseBodyPart;
 import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
+
+import org.asynchttpclient.handler.StreamedAsyncHandler;
+
+import org.reactivestreams.Publisher;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,40 +28,20 @@ import org.zalando.rxnakadi.domain.NakadiEvent;
 
 import com.google.common.net.MediaType;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
-
 import io.netty.handler.codec.http.HttpHeaders;
 
-import rx.Single;
+import rx.Observable;
+import rx.RxReactiveStreams;
 import rx.Subscriber;
 
-import rx.subjects.AsyncSubject;
+import rx.observables.StringObservable;
 
 /**
  * Creates the desired Nakadi events by consuming a continuous stream of raw data.
  *
- * <p>Implementation detail: Even if it takes a ReactiveX subscriber, it does not use an {@link rx.Observable}, but it
- * obeys the core tenets formulated for them:</p>
- *
- * <ul>
- *   <li>It checks the Subscriber's {@link Subscriber#isUnsubscribed()} status before emitting any item.</li>
- *   <li>It calls the Subscriber's {@link Subscriber#onNext(Object)} method any number of times and guarantees that
- *     these don't overlap.</li>
- *   <li>It calls either the Subscriber's {@link Subscriber#onCompleted()} or {@link Subscriber#onError(Throwable)}
- *     method, but not both, exactly once, and it does not call the the Subscriber's {@link Subscriber#onNext(Object)}
- *     method subsequently.</li>
- *   <li>Additionally it does not block.</li>
- * </ul>
- *
  * @param  <E>  Nakadi event type being produced
  */
-final class EventStreamHandler<E extends NakadiEvent> implements AsyncHandler<EventStreamHandler<E>> {
-
-    /**
-     * The HTTP header specifying the identifier to use when committing the cursor.
-     */
-    public static final String NAKADI_CLIENT_IDENTIFIER_HEADER = "X-Nakadi-StreamId";
+class EventStreamHandler<E extends NakadiEvent> implements StreamedAsyncHandler<EventStreamHandler<E>> {
 
     /**
      * Logging instance of this class.
@@ -71,7 +51,7 @@ final class EventStreamHandler<E extends NakadiEvent> implements AsyncHandler<Ev
     /**
      * Target, which receives the produced events.
      */
-    private final Subscriber<? super EventBatch<E>> subscriber;
+    protected final Subscriber<? super EventBatch<E>> subscriber;
 
     /**
      * Parses payloads.
@@ -79,22 +59,11 @@ final class EventStreamHandler<E extends NakadiEvent> implements AsyncHandler<Ev
     private final Function<? super String, ? extends EventBatch<E>> parser;
 
     /**
-     * Identifier of the Nakadi session used for this processor.
-     */
-    private final AsyncSubject<String> clientId = AsyncSubject.create();
-
-    /**
-     * As it is not guaranteed that every bodypart contains a complete event, a partly received event is stored until it
-     * was received completely.
-     */
-    private final List<HttpResponseBodyPart> bodyParts = new ArrayList<>(2);
-
-    /**
      * Charset being used to decode the endpoints payload.
      */
-    private volatile Charset charset;
+    protected volatile Charset charset;
 
-    private EventStreamHandler(final Subscriber<? super EventBatch<E>> subscriber,
+    protected EventStreamHandler(final Subscriber<? super EventBatch<E>> subscriber,
             final Function<? super String, ? extends EventBatch<E>> parser) {
         this.subscriber = requireNonNull(subscriber);
         this.parser = requireNonNull(parser);
@@ -112,47 +81,6 @@ final class EventStreamHandler<E extends NakadiEvent> implements AsyncHandler<Ev
             final Subscriber<? super EventBatch<E>> subscriber,
             final Function<? super String, ? extends EventBatch<E>> parser) {
         return new EventStreamHandler<>(subscriber, parser);
-    }
-
-    @Override
-    public void onThrowable(final Throwable t) {
-        abort(t);
-    }
-
-    @Override
-    public State onBodyPartReceived(final HttpResponseBodyPart bodyPart) {
-
-        if (subscriber.isUnsubscribed()) {
-            return State.ABORT;
-        }
-
-        // Sometimes, we get a body part containing nothing
-        if (bodyPart.length() > 0) {
-            final byte[] bytes = bodyPart.getBodyPartBytes();
-            String payload = new String(bytes, charset);
-
-            LOG.trace(payload);
-
-            // If the payload is valid, it is a complete event, therefore, if the bodypart before was only part of
-            // an event, it was corrupted and cannot be parsed.
-            if (isValidJson(payload)) {
-                bodyParts.clear();
-                subscriber.onNext(parser.apply(payload));
-            } else {
-                bodyParts.add(bodyPart);
-                payload = combinePayload(bodyParts, charset);
-
-                if (isValidJson(payload)) {
-                    bodyParts.clear();
-                    subscriber.onNext(parser.apply(payload));
-                } else {
-                    LOG.debug(
-                        "The response body part doesn't contain a full event. Wait for next body part to concatenate.");
-                }
-            }
-        }
-
-        return State.CONTINUE;
     }
 
     @Override
@@ -177,36 +105,43 @@ final class EventStreamHandler<E extends NakadiEvent> implements AsyncHandler<Ev
             return State.ABORT;
         }
 
-        final HttpHeaders httpHeaders = headers.getHeaders();
+        if (headers.isTrailling()) {
+            return State.CONTINUE;
+        }
 
-        // Try to get the encoding
-        final Charset parsedCharset;
         try {
-            parsedCharset =
-                Optional.ofNullable(httpHeaders.get(CONTENT_TYPE))    //
-                        .map(MediaType::parse)                        //
-                        .map(MediaType::charset)                      //
-                        .map(com.google.common.base.Optional::orNull) //
-                        .orElse(StandardCharsets.UTF_8);
-        } catch (final IllegalArgumentException e) {
+            parseCharset(headers.getHeaders());
+        } catch (final RuntimeException e) {
             return abort(e);
         }
-
-        charset = parsedCharset;
-
-        // Get the Nakadi session id
-        if (!httpHeaders.contains(NAKADI_CLIENT_IDENTIFIER_HEADER)) {
-            return abort(new IllegalStateException("Missing " + NAKADI_CLIENT_IDENTIFIER_HEADER + " HTTP header"));
-        }
-
-        clientId.onNext(httpHeaders.get(NAKADI_CLIENT_IDENTIFIER_HEADER));
-        clientId.onCompleted();
 
         return State.CONTINUE;
     }
 
-    public Single<String> getClientId() {
-        return clientId.toSingle();
+    @Override
+    public void onThrowable(final Throwable t) {
+        abort(t);
+    }
+
+    @Override
+    public State onStream(final Publisher<HttpResponseBodyPart> publisher) {
+
+        // parts -> bytes -> strings -> lines -> events
+        final Observable<HttpResponseBodyPart> parts = RxReactiveStreams.toObservable(publisher);
+        final Observable<byte[]> bytes = parts.map(HttpResponseBodyPart::getBodyPartBytes);
+        final Observable<String> strings = StringObservable.decode(bytes, charset);
+        final Observable<String> lines = StringObservable.byLine(strings);
+        final Observable<? extends EventBatch<E>> events = lines.map(parser::apply);
+
+        events.subscribe(subscriber);
+
+        return State.CONTINUE;
+    }
+
+    @Override
+    public State onBodyPartReceived(final HttpResponseBodyPart bodyPart) {
+        LOG.warn("Body part received, but streaming is used.");
+        return State.CONTINUE;
     }
 
     @Override
@@ -218,31 +153,18 @@ final class EventStreamHandler<E extends NakadiEvent> implements AsyncHandler<Ev
         return this;
     }
 
-    private static String combinePayload(final List<HttpResponseBodyPart> bodyParts, final Charset charset) {
-        final int length = bodyParts.stream().map(HttpResponseBodyPart::length).reduce(0, (a, b) -> a + b);
-        final ByteBuffer target = ByteBuffer.wrap(new byte[length]);
+    protected void parseCharset(final HttpHeaders httpHeaders) {
 
-        bodyParts.stream().map(HttpResponseBodyPart::getBodyPartBytes).forEach(target::put);
-
-        return new String(target.array(), charset);
+        // Try to get the encoding
+        charset =
+            Optional.ofNullable(httpHeaders.get(CONTENT_TYPE))    //
+                    .map(MediaType::parse)                        //
+                    .map(MediaType::charset)                      //
+                    .map(com.google.common.base.Optional::orNull) //
+                    .orElse(StandardCharsets.UTF_8);
     }
 
-    /**
-     * Checks if the bodypart contains only complete events (valid json).
-     *
-     * @param  data  The response data
-     */
-    private static boolean isValidJson(final String data) {
-        try {
-            new Gson().fromJson(data, Object.class);
-        } catch (final JsonSyntaxException ignored) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private State abort(final Throwable error) {
+    protected State abort(final Throwable error) {
         if (!subscriber.isUnsubscribed()) {
             subscriber.onError(error);
         }

--- a/src/main/java/org/zalando/rxnakadi/EventStreamSubscriptionProvider.java
+++ b/src/main/java/org/zalando/rxnakadi/EventStreamSubscriptionProvider.java
@@ -26,8 +26,9 @@ import org.slf4j.LoggerFactory;
 import org.zalando.rxnakadi.http.RequestProvider;
 import org.zalando.rxnakadi.http.resource.Problem;
 import org.zalando.rxnakadi.hystrix.HystrixCommands;
-import org.zalando.undertaking.oauth2.AccessToken;
 import org.zalando.rxnakadi.utils.StatusCodes;
+
+import org.zalando.undertaking.oauth2.AccessToken;
 
 import com.google.common.base.Strings;
 import com.google.common.net.HttpHeaders;

--- a/src/main/java/org/zalando/rxnakadi/NakadiModule.java
+++ b/src/main/java/org/zalando/rxnakadi/NakadiModule.java
@@ -1,11 +1,6 @@
 package org.zalando.rxnakadi;
 
-import static java.util.Objects.requireNonNull;
-
-import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
-
 import java.util.EnumSet;
-import java.util.function.Consumer;
 
 import javax.inject.Singleton;
 
@@ -15,9 +10,7 @@ import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
-import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 
@@ -27,8 +20,6 @@ import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
-
-import net.dongliu.gson.GsonJava8TypeAdapterFactory;
 
 @SuppressWarnings("static-method")
 public final class NakadiModule extends PrivateModule {
@@ -48,8 +39,8 @@ public final class NakadiModule extends PrivateModule {
     @Internal
     AsyncHttpClient provideNakadiHttpClient() {
         final AsyncHttpClientConfig config =
-                new DefaultAsyncHttpClientConfig.Builder().setRequestTimeout(-1) // disable waiting for request completion
-                        .build();
+            new DefaultAsyncHttpClientConfig.Builder().setRequestTimeout(-1) // disable waiting for request completion
+                                                      .build();
 
         return new DefaultAsyncHttpClient(config);
     }
@@ -59,9 +50,9 @@ public final class NakadiModule extends PrivateModule {
     ParseContext provideJsonPathParseContext(final Gson gson) {
         return JsonPath.using(
                 Configuration.builder()                     //
-                        .jsonProvider(new GsonJsonProvider(gson))   //
-                        .mappingProvider(new GsonMappingProvider(gson)) //
-                        .options(EnumSet.noneOf(Option.class))      //
-                        .build());
+                .jsonProvider(new GsonJsonProvider(gson))   //
+                .mappingProvider(new GsonMappingProvider(gson)) //
+                .options(EnumSet.noneOf(Option.class))      //
+                .build());
     }
 }

--- a/src/main/java/org/zalando/rxnakadi/NakadiPublisher.java
+++ b/src/main/java/org/zalando/rxnakadi/NakadiPublisher.java
@@ -21,6 +21,7 @@ import org.asynchttpclient.extras.rxjava.single.AsyncHttpSingle;
 import org.zalando.rxnakadi.domain.NakadiEvent;
 import org.zalando.rxnakadi.domain.PublishingProblem;
 import org.zalando.rxnakadi.hystrix.HystrixCommands;
+
 import org.zalando.undertaking.oauth2.AccessToken;
 
 import com.google.common.net.HttpHeaders;

--- a/src/main/java/org/zalando/rxnakadi/NakadiStreamProvider.java
+++ b/src/main/java/org/zalando/rxnakadi/NakadiStreamProvider.java
@@ -132,7 +132,8 @@ public class NakadiStreamProvider {
             final NakadiSubscription subscription, final Subscriber<? super EventBatch<E>> subscriber,
             final AtomicReference<Object> cursorRef) {
 
-        final EventStreamHandler<E> handler = EventStreamHandler.<E>create(subscriber, parser.forType(ctx.eventClass));
+        final SubscriptionAwareEventStreamHandler<E> handler = SubscriptionAwareEventStreamHandler.<E>create(subscriber,
+                parser.forType(ctx.eventClass));
 
         // Start the auto committer
         subscriber.add(cursorCommitter.autoCommit(ctx.nakadiUrl, handler.getClientId(),

--- a/src/main/java/org/zalando/rxnakadi/SubscriptionAwareEventStreamHandler.java
+++ b/src/main/java/org/zalando/rxnakadi/SubscriptionAwareEventStreamHandler.java
@@ -1,0 +1,84 @@
+package org.zalando.rxnakadi;
+
+import java.util.function.Function;
+
+import org.asynchttpclient.HttpResponseHeaders;
+
+import org.zalando.rxnakadi.domain.EventBatch;
+import org.zalando.rxnakadi.domain.NakadiEvent;
+
+import io.netty.handler.codec.http.HttpHeaders;
+
+import rx.Single;
+import rx.Subscriber;
+
+import rx.subjects.AsyncSubject;
+
+/**
+ * Creates the desired Nakadi events by consuming a continuous stream of raw data.
+ *
+ * <p>This implementation can only be used when interacting with Nakadi's High Level API as it expects to receive the
+ * {@code X-Nakadi-StreamId} HTTP header so that cursors can be committed for this particular stream.</p>
+ */
+public class SubscriptionAwareEventStreamHandler<E extends NakadiEvent> extends EventStreamHandler<E> {
+
+    /**
+     * The HTTP header specifying the identifier to use when committing the cursor.
+     */
+    public static final String NAKADI_CLIENT_IDENTIFIER_HEADER = "X-Nakadi-StreamId";
+
+    /**
+     * Identifier of the Nakadi session used for this processor.
+     */
+    private final AsyncSubject<String> clientId = AsyncSubject.create();
+
+    protected SubscriptionAwareEventStreamHandler(final Subscriber<? super EventBatch<E>> subscriber,
+            final Function<? super String, ? extends EventBatch<E>> parser) {
+        super(subscriber, parser);
+    }
+
+    /**
+     * Creates a new handler that publishes events of type {@link E} out of raw data.
+     *
+     * <p>Each valid event is passed to the subscriber for consuming.</p>
+     *
+     * @param  subscriber  target for the produced events
+     * @param  parser      parsing function that converts JSON payload to events
+     */
+    public static <E extends NakadiEvent> SubscriptionAwareEventStreamHandler<E> create(
+            final Subscriber<? super EventBatch<E>> subscriber,
+            final Function<? super String, ? extends EventBatch<E>> parser) {
+        return new SubscriptionAwareEventStreamHandler<>(subscriber, parser);
+    }
+
+    @Override
+    public State onHeadersReceived(final HttpResponseHeaders headers) {
+
+        if (subscriber.isUnsubscribed()) {
+            return State.ABORT;
+        }
+
+        final HttpHeaders httpHeaders = headers.getHeaders();
+
+        // Try to get the encoding
+        try {
+            parseCharset(headers.getHeaders());
+        } catch (final RuntimeException e) {
+            return abort(e);
+        }
+
+        // Get the Nakadi session id
+        if (!httpHeaders.contains(NAKADI_CLIENT_IDENTIFIER_HEADER)) {
+            return abort(new IllegalStateException("Missing " + NAKADI_CLIENT_IDENTIFIER_HEADER + " HTTP header"));
+        }
+
+        clientId.onNext(httpHeaders.get(NAKADI_CLIENT_IDENTIFIER_HEADER));
+        clientId.onCompleted();
+
+        return State.CONTINUE;
+    }
+
+    public Single<String> getClientId() {
+        return clientId.toSingle();
+    }
+}

--- a/src/main/java/org/zalando/rxnakadi/hystrix/HystrixCommands.java
+++ b/src/main/java/org/zalando/rxnakadi/hystrix/HystrixCommands.java
@@ -6,6 +6,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.text.MessageFormat;
+
 import java.util.concurrent.Callable;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
In the gift-card-file-exporter the `EventStreamHandler` was changed to use Async HTTP client's StreamedAsyncHandler.

This avoids fiddling around with the body parts if an event's payload does not fit into a single body part.

To support a stream handler for both, the old and new Nakadi API, the `EventStreamHandler` was stripped of all things required for the new API. Instead the new class `SubscriptionAwareEventStreamHandler` was added, which provides the required functionality on top of `EventStreamHandler`.