### PR TITLE
Use rxjava-extras instead of rx-java strings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,9 @@
             <version>1.2.1</version>
         </dependency>
         <dependency>
-            <groupId>io.reactivex</groupId>
-            <artifactId>rxjava-string</artifactId>
-            <version>1.1.0</version>
+            <groupId>com.github.davidmoten</groupId>
+            <artifactId>rxjava-extras</artifactId>
+            <version>0.8.0.5</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>

--- a/src/main/java/org/zalando/rxnakadi/EventStreamSubscriptionProvider.java
+++ b/src/main/java/org/zalando/rxnakadi/EventStreamSubscriptionProvider.java
@@ -20,9 +20,6 @@ import org.asynchttpclient.Response;
 
 import org.asynchttpclient.extras.rxjava.single.AsyncHttpSingle;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.zalando.rxnakadi.http.RequestProvider;
 import org.zalando.rxnakadi.http.resource.Problem;
 import org.zalando.rxnakadi.hystrix.HystrixCommands;
@@ -45,8 +42,6 @@ import rx.Observable;
 import rx.Single;
 
 final class EventStreamSubscriptionProvider extends RequestProvider {
-
-    private static final Logger LOG = LoggerFactory.getLogger(EventStreamSubscriptionProvider.class);
 
     private static final HystrixObservableCommand.Setter SETTER =
         HystrixObservableCommand.Setter.withGroupKey(                                                             //


### PR DESCRIPTION
This solves the backpressure problem of `StringObservable.byLine(…)`.