### PR TITLE
Move AccessToken to rxnakadi package.

### DIFF
--- a/src/main/java/org/zalando/rxnakadi/AccessToken.java
+++ b/src/main/java/org/zalando/rxnakadi/AccessToken.java
@@ -1,4 +1,4 @@
-package org.zalando.undertaking.oauth2;
+package org.zalando.rxnakadi;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/src/main/java/org/zalando/rxnakadi/http/ahc/AhcNakadiHttpClient.java
+++ b/src/main/java/org/zalando/rxnakadi/http/ahc/AhcNakadiHttpClient.java
@@ -49,6 +49,7 @@ import org.asynchttpclient.uri.Uri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.zalando.rxnakadi.AccessToken;
 import org.zalando.rxnakadi.EventType;
 import org.zalando.rxnakadi.NakadiPublishingException;
 import org.zalando.rxnakadi.SubscriptionDescriptor;
@@ -57,8 +58,6 @@ import org.zalando.rxnakadi.http.NakadiHttp;
 import org.zalando.rxnakadi.http.NakadiHttpClient;
 import org.zalando.rxnakadi.hystrix.HystrixCommands;
 import org.zalando.rxnakadi.inject.Nakadi;
-
-import org.zalando.undertaking.oauth2.AccessToken;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/src/main/java/org/zalando/rxnakadi/inject/guice/NakadiModule.java
+++ b/src/main/java/org/zalando/rxnakadi/inject/guice/NakadiModule.java
@@ -8,13 +8,12 @@ import javax.inject.Singleton;
 
 import org.asynchttpclient.AsyncHttpClient;
 
+import org.zalando.rxnakadi.AccessToken;
 import org.zalando.rxnakadi.NakadiTopicFactory;
 import org.zalando.rxnakadi.http.NakadiHttpClient;
 import org.zalando.rxnakadi.http.ahc.AhcNakadiHttpClient;
 import org.zalando.rxnakadi.inject.Nakadi;
 import org.zalando.rxnakadi.internal.DefaultNakadiTopicFactory;
-
-import org.zalando.undertaking.oauth2.AccessToken;
 
 import com.google.gson.Gson;
 
@@ -27,6 +26,8 @@ import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
+
+import rx.Single;
 
 /**
  * Provides bindings for {@link NakadiTopicFactory}.

--- a/src/test/java/org/zalando/rxnakadi/http/NakadiHttpClientIT.java
+++ b/src/test/java/org/zalando/rxnakadi/http/NakadiHttpClientIT.java
@@ -31,11 +31,10 @@ import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.zalando.rxnakadi.AccessToken;
 import org.zalando.rxnakadi.EventType;
 import org.zalando.rxnakadi.NakadiPublishingException;
 import org.zalando.rxnakadi.domain.PublishingProblem;
-
-import org.zalando.undertaking.oauth2.AccessToken;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 


### PR DESCRIPTION
This is far more secure when using together with undertaking. If the classes' ABI diverge, there will be nasty runtime errors.